### PR TITLE
Fix Zip Slip Vulnerability in UnzipUtil 

### DIFF
--- a/app/src/main/java/com/rdapps/gamepad/util/UnzipUtil.java
+++ b/app/src/main/java/com/rdapps/gamepad/util/UnzipUtil.java
@@ -19,33 +19,37 @@ public class UnzipUtil {
         dirChecker("");
     }
 
-    public void unzip() {
-        try {
-            FileInputStream fin = zipFile.createInputStream();
-            ZipInputStream zin = new ZipInputStream(fin);
-            ZipEntry ze = null;
+        public void unzip() {
+        try (FileInputStream fin = zipFile.createInputStream();
+             ZipInputStream zin = new ZipInputStream(fin)) {
+            ZipEntry ze;
             while ((ze = zin.getNextEntry()) != null) {
                 Log.v("Decompress", "Unzipping " + ze.getName());
-
+                
                 if (ze.isDirectory()) {
                     dirChecker(ze.getName());
                 } else {
                     if (ze.getName() != null && !ze.getName().trim().isEmpty()) {
-                        FileOutputStream fout = new FileOutputStream(
-                                location + File.separator + ze.getName());
-
-                        byte[] buffer = new byte[8192];
-                        int len;
-                        while ((len = zin.read(buffer)) != -1) {
-                            fout.write(buffer, 0, len);
+                        File newFile = new File(location, ze.getName());
+                        // Validate that the file path is within the intended extraction directory
+                        if (!newFile.toPath().normalize().startsWith(new File(location).toPath().normalize())) {
+                            throw new RuntimeException("Bad zip entry: " + ze.getName());
                         }
-                        fout.close();
+                        
+                        // Ensure parent directory exists
+                        new File(newFile.getParent()).mkdirs();
+                        try (FileOutputStream fout = new FileOutputStream(newFile)) {
+                            byte[] buffer = new byte[8192];
+                            int len;
+                            while ((len = zin.read(buffer)) != -1) {
+                                fout.write(buffer, 0, len);
+                            }
+                        }
                     }
                     zin.closeEntry();
                 }
 
             }
-            zin.close();
         } catch (Exception e) {
             Log.e("Decompress", "unzip", e);
         }


### PR DESCRIPTION
## Description
This PR addresses a critical Zip Slip vulnerability (CWE-22: Path Traversal) in the UnzipUtil file that could allow malicious zip archives to write files outside the intended extraction directory.

This vulnerability was initially found and fixed in Xilinx/RapidWright@acbe053, corresponding to CVE-2018-1002201.

**Solution:**
1. Path Validation: Added normalized path checking to ensure files stay within extraction directory
2. Resource Management: Improved with try-with-resources pattern
3. Error Handling: Clear exceptions for malicious entries

**References:** 
1. Xilinx/RapidWright@acbe053
2. https://nvd.nist.gov/vuln/detail/CVE-2018-1002201
